### PR TITLE
Update ta linker scripts and entry points so that them can run with optee 3.8.0

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -3,9 +3,12 @@ linker = "optee/toolchains/aarch64/bin/aarch64-linux-gnu-ld"
 ar = "optee/toolchains/aarch64/bin/aarch64-linux-gnu-gcc-ar"
 rustflags = [
     "-C", "link-arg=-nostdlib",
+    "-C", "link-arg=-e__ta_entry",
+    "-C", "link-arg=-pie",
     "-C", "link-arg=-Tta.lds",
     "-C", "link-arg=--sort-section=alignment",
-    "-C", "link-arg=-pie",
+    "-C", "link-arg=-z",
+    "-C", "link-arg=max-page-size=4096",
     "-C", "link-dead-code",
 ]
 
@@ -18,9 +21,12 @@ linker = "optee/toolchains/aarch32/bin/arm-linux-gnueabihf-ld.bfd"
 ar = "optee/toolchains/aarch32/bin/arm-linux-gnueabihf-ar"
 rustflags = [
     "-C", "link-arg=-nostdlib",
+    "-C", "link-arg=-e__ta_entry",
+    "-C", "link-arg=-pie",
     "-C", "link-arg=-Tta.lds",
     "-C", "link-arg=--sort-section=alignment",
-    "-C", "link-arg=-pie",
+    "-C", "link-arg=-z",
+    "-C", "link-arg=max-page-size=4096",
     "-C", "link-dead-code",
 ]
 

--- a/examples/acipher/ta/Makefile
+++ b/examples/acipher/ta/Makefile
@@ -8,13 +8,13 @@ OPTEE_DIR ?= ../../../optee
 
 ifeq ($(ARCH), arm)
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/aarch32/bin
 	OBJCOPY := $(OPTEE_BIN)/arm-linux-gnueabihf-objcopy
 	TARGET := arm-unknown-optee-trustzone
 else
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/$(ARCH)/bin
 	OBJCOPY := $(OPTEE_BIN)/aarch64-linux-gnu-objcopy
 	TARGET := aarch64-unknown-optee-trustzone

--- a/examples/acipher/ta/ta_aarch64.lds
+++ b/examples/acipher/ta/ta_aarch64.lds
@@ -1,92 +1,62 @@
-OUTPUT_FORMAT("elf64-littleaarch64", "elf64-bigaarch64", "elf64-littleaarch64")
+OUTPUT_FORMAT("elf64-littleaarch64")
 OUTPUT_ARCH(aarch64)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }
-

--- a/examples/acipher/ta/ta_arm.lds
+++ b/examples/acipher/ta/ta_arm.lds
@@ -1,91 +1,62 @@
 OUTPUT_FORMAT("elf32-littlearm")
 OUTPUT_ARCH(arm)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }

--- a/examples/acipher/ta/ta_static.rs
+++ b/examples/acipher/ta/ta_static.rs
@@ -5,12 +5,24 @@ pub static mut trace_level: libc::c_int = TRACE_LEVEL;
 pub static trace_ext_prefix: &[u8] = TRACE_EXT_PREFIX;
 
 extern "C" {
-    fn __utee_entry(
+    pub fn __utee_entry(
         func: libc::c_ulong,
         session_id: libc::c_ulong,
         up: *mut optee_utee_sys::utee_params,
         cmd_id: libc::c_ulong,
-    );
+    ) -> optee_utee_sys::TEE_Result;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn __ta_entry(
+    func: libc::c_ulong,
+    session_id: libc::c_ulong,
+    up: *mut optee_utee_sys::utee_params,
+    cmd_id: libc::c_ulong,
+) -> ! {
+    let res: optee_utee_sys::TEE_Result = __utee_entry(func, session_id, up, cmd_id);
+
+    optee_utee_sys::utee_return(res.into());
 }
 
 #[no_mangle]
@@ -19,13 +31,7 @@ pub static ta_head: optee_utee_sys::ta_head = optee_utee_sys::ta_head {
     uuid: TA_UUID,
     stack_size: TA_STACK_SIZE + TA_FRAMEWORK_STACK_SIZE,
     flags: TA_FLAGS,
-    entry: __utee_entry
-        as unsafe extern "C" fn(
-            libc::c_ulong,
-            libc::c_ulong,
-            *mut optee_utee_sys::utee_params,
-            libc::c_ulong,
-        ),
+    depr_entry: 0xFFFF_FFFF_FFFF_FFFF,
 };
 
 #[no_mangle]

--- a/examples/aes/ta/Makefile
+++ b/examples/aes/ta/Makefile
@@ -8,13 +8,13 @@ OPTEE_DIR ?= ../../../optee
 
 ifeq ($(ARCH), arm)
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/aarch32/bin
 	OBJCOPY := $(OPTEE_BIN)/arm-linux-gnueabihf-objcopy
 	TARGET := arm-unknown-optee-trustzone
 else
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/$(ARCH)/bin
 	OBJCOPY := $(OPTEE_BIN)/aarch64-linux-gnu-objcopy
 	TARGET := aarch64-unknown-optee-trustzone

--- a/examples/aes/ta/ta_aarch64.lds
+++ b/examples/aes/ta/ta_aarch64.lds
@@ -1,92 +1,62 @@
-OUTPUT_FORMAT("elf64-littleaarch64", "elf64-bigaarch64", "elf64-littleaarch64")
+OUTPUT_FORMAT("elf64-littleaarch64")
 OUTPUT_ARCH(aarch64)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }
-

--- a/examples/aes/ta/ta_arm.lds
+++ b/examples/aes/ta/ta_arm.lds
@@ -1,91 +1,62 @@
 OUTPUT_FORMAT("elf32-littlearm")
 OUTPUT_ARCH(arm)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }

--- a/examples/aes/ta/ta_static.rs
+++ b/examples/aes/ta/ta_static.rs
@@ -5,12 +5,24 @@ pub static mut trace_level: libc::c_int = TRACE_LEVEL;
 pub static trace_ext_prefix: &[u8] = TRACE_EXT_PREFIX;
 
 extern "C" {
-    fn __utee_entry(
+    pub fn __utee_entry(
         func: libc::c_ulong,
         session_id: libc::c_ulong,
         up: *mut optee_utee_sys::utee_params,
         cmd_id: libc::c_ulong,
-    );
+    ) -> optee_utee_sys::TEE_Result;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn __ta_entry(
+    func: libc::c_ulong,
+    session_id: libc::c_ulong,
+    up: *mut optee_utee_sys::utee_params,
+    cmd_id: libc::c_ulong,
+) -> ! {
+    let res: optee_utee_sys::TEE_Result = __utee_entry(func, session_id, up, cmd_id);
+
+    optee_utee_sys::utee_return(res.into());
 }
 
 #[no_mangle]
@@ -19,13 +31,7 @@ pub static ta_head: optee_utee_sys::ta_head = optee_utee_sys::ta_head {
     uuid: TA_UUID,
     stack_size: TA_STACK_SIZE + TA_FRAMEWORK_STACK_SIZE,
     flags: TA_FLAGS,
-    entry: __utee_entry
-        as unsafe extern "C" fn(
-            libc::c_ulong,
-            libc::c_ulong,
-            *mut optee_utee_sys::utee_params,
-            libc::c_ulong,
-        ),
+    depr_entry: 0xFFFF_FFFF_FFFF_FFFF,
 };
 
 #[no_mangle]

--- a/examples/authentication/ta/Makefile
+++ b/examples/authentication/ta/Makefile
@@ -8,13 +8,13 @@ OPTEE_DIR ?= ../../../optee
 
 ifeq ($(ARCH), arm)
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/aarch32/bin
 	OBJCOPY := $(OPTEE_BIN)/arm-linux-gnueabihf-objcopy
 	TARGET := arm-unknown-optee-trustzone
 else
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/$(ARCH)/bin
 	OBJCOPY := $(OPTEE_BIN)/aarch64-linux-gnu-objcopy
 	TARGET := aarch64-unknown-optee-trustzone

--- a/examples/authentication/ta/ta_aarch64.lds
+++ b/examples/authentication/ta/ta_aarch64.lds
@@ -1,92 +1,62 @@
-OUTPUT_FORMAT("elf64-littleaarch64", "elf64-bigaarch64", "elf64-littleaarch64")
+OUTPUT_FORMAT("elf64-littleaarch64")
 OUTPUT_ARCH(aarch64)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }
-

--- a/examples/authentication/ta/ta_arm.lds
+++ b/examples/authentication/ta/ta_arm.lds
@@ -1,91 +1,62 @@
 OUTPUT_FORMAT("elf32-littlearm")
 OUTPUT_ARCH(arm)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }

--- a/examples/authentication/ta/ta_static.rs
+++ b/examples/authentication/ta/ta_static.rs
@@ -5,12 +5,24 @@ pub static mut trace_level: libc::c_int = TRACE_LEVEL;
 pub static trace_ext_prefix: &[u8] = TRACE_EXT_PREFIX;
 
 extern "C" {
-    fn __utee_entry(
+    pub fn __utee_entry(
         func: libc::c_ulong,
         session_id: libc::c_ulong,
         up: *mut optee_utee_sys::utee_params,
         cmd_id: libc::c_ulong,
-    );
+    ) -> optee_utee_sys::TEE_Result;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn __ta_entry(
+    func: libc::c_ulong,
+    session_id: libc::c_ulong,
+    up: *mut optee_utee_sys::utee_params,
+    cmd_id: libc::c_ulong,
+) -> ! {
+    let res: optee_utee_sys::TEE_Result = __utee_entry(func, session_id, up, cmd_id);
+
+    optee_utee_sys::utee_return(res.into());
 }
 
 #[no_mangle]
@@ -19,13 +31,7 @@ pub static ta_head: optee_utee_sys::ta_head = optee_utee_sys::ta_head {
     uuid: TA_UUID,
     stack_size: TA_STACK_SIZE + TA_FRAMEWORK_STACK_SIZE,
     flags: TA_FLAGS,
-    entry: __utee_entry
-        as unsafe extern "C" fn(
-            libc::c_ulong,
-            libc::c_ulong,
-            *mut optee_utee_sys::utee_params,
-            libc::c_ulong,
-        ),
+    depr_entry: 0xFFFF_FFFF_FFFF_FFFF,
 };
 
 #[no_mangle]

--- a/examples/big_int/ta/Makefile
+++ b/examples/big_int/ta/Makefile
@@ -8,13 +8,13 @@ OPTEE_DIR ?= ../../../optee
 
 ifeq ($(ARCH), arm)
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/aarch32/bin
 	OBJCOPY := $(OPTEE_BIN)/arm-linux-gnueabihf-objcopy
 	TARGET := arm-unknown-optee-trustzone
 else
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/$(ARCH)/bin
 	OBJCOPY := $(OPTEE_BIN)/aarch64-linux-gnu-objcopy
 	TARGET := aarch64-unknown-optee-trustzone

--- a/examples/big_int/ta/ta_aarch64.lds
+++ b/examples/big_int/ta/ta_aarch64.lds
@@ -1,92 +1,62 @@
-OUTPUT_FORMAT("elf64-littleaarch64", "elf64-bigaarch64", "elf64-littleaarch64")
+OUTPUT_FORMAT("elf64-littleaarch64")
 OUTPUT_ARCH(aarch64)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }
-

--- a/examples/big_int/ta/ta_arm.lds
+++ b/examples/big_int/ta/ta_arm.lds
@@ -1,91 +1,62 @@
 OUTPUT_FORMAT("elf32-littlearm")
 OUTPUT_ARCH(arm)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }

--- a/examples/big_int/ta/ta_static.rs
+++ b/examples/big_int/ta/ta_static.rs
@@ -5,12 +5,24 @@ pub static mut trace_level: libc::c_int = TRACE_LEVEL;
 pub static trace_ext_prefix: &[u8] = TRACE_EXT_PREFIX;
 
 extern "C" {
-    fn __utee_entry(
+    pub fn __utee_entry(
         func: libc::c_ulong,
         session_id: libc::c_ulong,
         up: *mut optee_utee_sys::utee_params,
         cmd_id: libc::c_ulong,
-    );
+    ) -> optee_utee_sys::TEE_Result;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn __ta_entry(
+    func: libc::c_ulong,
+    session_id: libc::c_ulong,
+    up: *mut optee_utee_sys::utee_params,
+    cmd_id: libc::c_ulong,
+) -> ! {
+    let res: optee_utee_sys::TEE_Result = __utee_entry(func, session_id, up, cmd_id);
+
+    optee_utee_sys::utee_return(res.into());
 }
 
 #[no_mangle]
@@ -19,13 +31,7 @@ pub static ta_head: optee_utee_sys::ta_head = optee_utee_sys::ta_head {
     uuid: TA_UUID,
     stack_size: TA_STACK_SIZE + TA_FRAMEWORK_STACK_SIZE,
     flags: TA_FLAGS,
-    entry: __utee_entry
-        as unsafe extern "C" fn(
-            libc::c_ulong,
-            libc::c_ulong,
-            *mut optee_utee_sys::utee_params,
-            libc::c_ulong,
-        ),
+    depr_entry: 0xFFFF_FFFF_FFFF_FFFF,
 };
 
 #[no_mangle]

--- a/examples/diffie_hellman/ta/Makefile
+++ b/examples/diffie_hellman/ta/Makefile
@@ -8,13 +8,13 @@ OPTEE_DIR ?= ../../../optee
 
 ifeq ($(ARCH), arm)
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/aarch32/bin
 	OBJCOPY := $(OPTEE_BIN)/arm-linux-gnueabihf-objcopy
 	TARGET := arm-unknown-optee-trustzone
 else
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/$(ARCH)/bin
 	OBJCOPY := $(OPTEE_BIN)/aarch64-linux-gnu-objcopy
 	TARGET := aarch64-unknown-optee-trustzone

--- a/examples/diffie_hellman/ta/ta_aarch64.lds
+++ b/examples/diffie_hellman/ta/ta_aarch64.lds
@@ -1,92 +1,62 @@
-OUTPUT_FORMAT("elf64-littleaarch64", "elf64-bigaarch64", "elf64-littleaarch64")
+OUTPUT_FORMAT("elf64-littleaarch64")
 OUTPUT_ARCH(aarch64)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }
-

--- a/examples/diffie_hellman/ta/ta_arm.lds
+++ b/examples/diffie_hellman/ta/ta_arm.lds
@@ -1,91 +1,62 @@
 OUTPUT_FORMAT("elf32-littlearm")
 OUTPUT_ARCH(arm)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }

--- a/examples/diffie_hellman/ta/ta_static.rs
+++ b/examples/diffie_hellman/ta/ta_static.rs
@@ -5,12 +5,24 @@ pub static mut trace_level: libc::c_int = TRACE_LEVEL;
 pub static trace_ext_prefix: &[u8] = TRACE_EXT_PREFIX;
 
 extern "C" {
-    fn __utee_entry(
+    pub fn __utee_entry(
         func: libc::c_ulong,
         session_id: libc::c_ulong,
         up: *mut optee_utee_sys::utee_params,
         cmd_id: libc::c_ulong,
-    );
+    ) -> optee_utee_sys::TEE_Result;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn __ta_entry(
+    func: libc::c_ulong,
+    session_id: libc::c_ulong,
+    up: *mut optee_utee_sys::utee_params,
+    cmd_id: libc::c_ulong,
+) -> ! {
+    let res: optee_utee_sys::TEE_Result = __utee_entry(func, session_id, up, cmd_id);
+
+    optee_utee_sys::utee_return(res.into());
 }
 
 #[no_mangle]
@@ -19,13 +31,7 @@ pub static ta_head: optee_utee_sys::ta_head = optee_utee_sys::ta_head {
     uuid: TA_UUID,
     stack_size: TA_STACK_SIZE + TA_FRAMEWORK_STACK_SIZE,
     flags: TA_FLAGS,
-    entry: __utee_entry
-        as unsafe extern "C" fn(
-            libc::c_ulong,
-            libc::c_ulong,
-            *mut optee_utee_sys::utee_params,
-            libc::c_ulong,
-        ),
+    depr_entry: 0xFFFF_FFFF_FFFF_FFFF,
 };
 
 #[no_mangle]

--- a/examples/digest/ta/Makefile
+++ b/examples/digest/ta/Makefile
@@ -8,13 +8,13 @@ OPTEE_DIR ?= ../../../optee
 
 ifeq ($(ARCH), arm)
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/aarch32/bin
 	OBJCOPY := $(OPTEE_BIN)/arm-linux-gnueabihf-objcopy
 	TARGET := arm-unknown-optee-trustzone
 else
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/$(ARCH)/bin
 	OBJCOPY := $(OPTEE_BIN)/aarch64-linux-gnu-objcopy
 	TARGET := aarch64-unknown-optee-trustzone

--- a/examples/digest/ta/ta_aarch64.lds
+++ b/examples/digest/ta/ta_aarch64.lds
@@ -1,92 +1,62 @@
-OUTPUT_FORMAT("elf64-littleaarch64", "elf64-bigaarch64", "elf64-littleaarch64")
+OUTPUT_FORMAT("elf64-littleaarch64")
 OUTPUT_ARCH(aarch64)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }
-

--- a/examples/digest/ta/ta_arm.lds
+++ b/examples/digest/ta/ta_arm.lds
@@ -1,91 +1,62 @@
 OUTPUT_FORMAT("elf32-littlearm")
 OUTPUT_ARCH(arm)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }

--- a/examples/digest/ta/ta_static.rs
+++ b/examples/digest/ta/ta_static.rs
@@ -5,12 +5,24 @@ pub static mut trace_level: libc::c_int = TRACE_LEVEL;
 pub static trace_ext_prefix: &[u8] = TRACE_EXT_PREFIX;
 
 extern "C" {
-    fn __utee_entry(
+    pub fn __utee_entry(
         func: libc::c_ulong,
         session_id: libc::c_ulong,
         up: *mut optee_utee_sys::utee_params,
         cmd_id: libc::c_ulong,
-    );
+    ) -> optee_utee_sys::TEE_Result;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn __ta_entry(
+    func: libc::c_ulong,
+    session_id: libc::c_ulong,
+    up: *mut optee_utee_sys::utee_params,
+    cmd_id: libc::c_ulong,
+) -> ! {
+    let res: optee_utee_sys::TEE_Result = __utee_entry(func, session_id, up, cmd_id);
+
+    optee_utee_sys::utee_return(res.into());
 }
 
 #[no_mangle]
@@ -19,13 +31,7 @@ pub static ta_head: optee_utee_sys::ta_head = optee_utee_sys::ta_head {
     uuid: TA_UUID,
     stack_size: TA_STACK_SIZE + TA_FRAMEWORK_STACK_SIZE,
     flags: TA_FLAGS,
-    entry: __utee_entry
-        as unsafe extern "C" fn(
-            libc::c_ulong,
-            libc::c_ulong,
-            *mut optee_utee_sys::utee_params,
-            libc::c_ulong,
-        ),
+    depr_entry: 0xFFFF_FFFF_FFFF_FFFF,
 };
 
 #[no_mangle]

--- a/examples/hello_world/ta/Makefile
+++ b/examples/hello_world/ta/Makefile
@@ -8,13 +8,13 @@ OPTEE_DIR ?= ../../../optee
 
 ifeq ($(ARCH), arm)
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/aarch32/bin
 	OBJCOPY := $(OPTEE_BIN)/arm-linux-gnueabihf-objcopy
 	TARGET := arm-unknown-optee-trustzone
 else
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/$(ARCH)/bin
 	OBJCOPY := $(OPTEE_BIN)/aarch64-linux-gnu-objcopy
 	TARGET := aarch64-unknown-optee-trustzone

--- a/examples/hello_world/ta/ta_aarch64.lds
+++ b/examples/hello_world/ta/ta_aarch64.lds
@@ -1,92 +1,62 @@
-OUTPUT_FORMAT("elf64-littleaarch64", "elf64-bigaarch64", "elf64-littleaarch64")
+OUTPUT_FORMAT("elf64-littleaarch64")
 OUTPUT_ARCH(aarch64)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }
-

--- a/examples/hello_world/ta/ta_arm.lds
+++ b/examples/hello_world/ta/ta_arm.lds
@@ -1,91 +1,62 @@
 OUTPUT_FORMAT("elf32-littlearm")
 OUTPUT_ARCH(arm)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }

--- a/examples/hello_world/ta/ta_static.rs
+++ b/examples/hello_world/ta/ta_static.rs
@@ -5,12 +5,24 @@ pub static mut trace_level: libc::c_int = TRACE_LEVEL;
 pub static trace_ext_prefix: &[u8] = TRACE_EXT_PREFIX;
 
 extern "C" {
-    fn __utee_entry(
+    pub fn __utee_entry(
         func: libc::c_ulong,
         session_id: libc::c_ulong,
         up: *mut optee_utee_sys::utee_params,
         cmd_id: libc::c_ulong,
-    );
+    ) -> optee_utee_sys::TEE_Result;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn __ta_entry(
+    func: libc::c_ulong,
+    session_id: libc::c_ulong,
+    up: *mut optee_utee_sys::utee_params,
+    cmd_id: libc::c_ulong,
+) -> ! {
+    let res: optee_utee_sys::TEE_Result = __utee_entry(func, session_id, up, cmd_id);
+
+    optee_utee_sys::utee_return(res.into());
 }
 
 #[no_mangle]
@@ -19,13 +31,7 @@ pub static ta_head: optee_utee_sys::ta_head = optee_utee_sys::ta_head {
     uuid: TA_UUID,
     stack_size: TA_STACK_SIZE + TA_FRAMEWORK_STACK_SIZE,
     flags: TA_FLAGS,
-    entry: __utee_entry
-        as unsafe extern "C" fn(
-            libc::c_ulong,
-            libc::c_ulong,
-            *mut optee_utee_sys::utee_params,
-            libc::c_ulong,
-        ),
+    depr_entry: 0xFFFF_FFFF_FFFF_FFFF,
 };
 
 #[no_mangle]

--- a/examples/hotp/ta/Makefile
+++ b/examples/hotp/ta/Makefile
@@ -8,13 +8,13 @@ OPTEE_DIR ?= ../../../optee
 
 ifeq ($(ARCH), arm)
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/aarch32/bin
 	OBJCOPY := $(OPTEE_BIN)/arm-linux-gnueabihf-objcopy
 	TARGET := arm-unknown-optee-trustzone
 else
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/$(ARCH)/bin
 	OBJCOPY := $(OPTEE_BIN)/aarch64-linux-gnu-objcopy
 	TARGET := aarch64-unknown-optee-trustzone

--- a/examples/hotp/ta/ta_aarch64.lds
+++ b/examples/hotp/ta/ta_aarch64.lds
@@ -1,92 +1,62 @@
-OUTPUT_FORMAT("elf64-littleaarch64", "elf64-bigaarch64", "elf64-littleaarch64")
+OUTPUT_FORMAT("elf64-littleaarch64")
 OUTPUT_ARCH(aarch64)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }
-

--- a/examples/hotp/ta/ta_arm.lds
+++ b/examples/hotp/ta/ta_arm.lds
@@ -1,91 +1,62 @@
 OUTPUT_FORMAT("elf32-littlearm")
 OUTPUT_ARCH(arm)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }

--- a/examples/hotp/ta/ta_static.rs
+++ b/examples/hotp/ta/ta_static.rs
@@ -5,12 +5,24 @@ pub static mut trace_level: libc::c_int = TRACE_LEVEL;
 pub static trace_ext_prefix: &[u8] = TRACE_EXT_PREFIX;
 
 extern "C" {
-    fn __utee_entry(
+    pub fn __utee_entry(
         func: libc::c_ulong,
         session_id: libc::c_ulong,
         up: *mut optee_utee_sys::utee_params,
         cmd_id: libc::c_ulong,
-    );
+    ) -> optee_utee_sys::TEE_Result;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn __ta_entry(
+    func: libc::c_ulong,
+    session_id: libc::c_ulong,
+    up: *mut optee_utee_sys::utee_params,
+    cmd_id: libc::c_ulong,
+) -> ! {
+    let res: optee_utee_sys::TEE_Result = __utee_entry(func, session_id, up, cmd_id);
+
+    optee_utee_sys::utee_return(res.into());
 }
 
 #[no_mangle]
@@ -19,13 +31,7 @@ pub static ta_head: optee_utee_sys::ta_head = optee_utee_sys::ta_head {
     uuid: TA_UUID,
     stack_size: TA_STACK_SIZE + TA_FRAMEWORK_STACK_SIZE,
     flags: TA_FLAGS,
-    entry: __utee_entry
-        as unsafe extern "C" fn(
-            libc::c_ulong,
-            libc::c_ulong,
-            *mut optee_utee_sys::utee_params,
-            libc::c_ulong,
-        ),
+    depr_entry: 0xFFFF_FFFF_FFFF_FFFF,
 };
 
 #[no_mangle]

--- a/examples/message_passing_interface/ta/Makefile
+++ b/examples/message_passing_interface/ta/Makefile
@@ -8,13 +8,13 @@ OPTEE_DIR ?= ../../../optee
 
 ifeq ($(ARCH), arm)
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/aarch32/bin
 	OBJCOPY := $(OPTEE_BIN)/arm-linux-gnueabihf-objcopy
 	TARGET := arm-unknown-optee-trustzone
 else
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/$(ARCH)/bin
 	OBJCOPY := $(OPTEE_BIN)/aarch64-linux-gnu-objcopy
 	TARGET := aarch64-unknown-optee-trustzone

--- a/examples/message_passing_interface/ta/ta_aarch64.lds
+++ b/examples/message_passing_interface/ta/ta_aarch64.lds
@@ -1,92 +1,62 @@
-OUTPUT_FORMAT("elf64-littleaarch64", "elf64-bigaarch64", "elf64-littleaarch64")
+OUTPUT_FORMAT("elf64-littleaarch64")
 OUTPUT_ARCH(aarch64)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }
-

--- a/examples/message_passing_interface/ta/ta_arm.lds
+++ b/examples/message_passing_interface/ta/ta_arm.lds
@@ -1,91 +1,62 @@
 OUTPUT_FORMAT("elf32-littlearm")
 OUTPUT_ARCH(arm)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }

--- a/examples/random/ta/Makefile
+++ b/examples/random/ta/Makefile
@@ -8,13 +8,13 @@ OPTEE_DIR ?= ../../../optee
 
 ifeq ($(ARCH), arm)
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/aarch32/bin
 	OBJCOPY := $(OPTEE_BIN)/arm-linux-gnueabihf-objcopy
 	TARGET := arm-unknown-optee-trustzone
 else
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/$(ARCH)/bin
 	OBJCOPY := $(OPTEE_BIN)/aarch64-linux-gnu-objcopy
 	TARGET := aarch64-unknown-optee-trustzone

--- a/examples/random/ta/ta_aarch64.lds
+++ b/examples/random/ta/ta_aarch64.lds
@@ -1,92 +1,62 @@
-OUTPUT_FORMAT("elf64-littleaarch64", "elf64-bigaarch64", "elf64-littleaarch64")
+OUTPUT_FORMAT("elf64-littleaarch64")
 OUTPUT_ARCH(aarch64)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }
-

--- a/examples/random/ta/ta_arm.lds
+++ b/examples/random/ta/ta_arm.lds
@@ -1,91 +1,62 @@
 OUTPUT_FORMAT("elf32-littlearm")
 OUTPUT_ARCH(arm)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }

--- a/examples/random/ta/ta_static.rs
+++ b/examples/random/ta/ta_static.rs
@@ -5,12 +5,24 @@ pub static mut trace_level: libc::c_int = TRACE_LEVEL;
 pub static trace_ext_prefix: &[u8] = TRACE_EXT_PREFIX;
 
 extern "C" {
-    fn __utee_entry(
+    pub fn __utee_entry(
         func: libc::c_ulong,
         session_id: libc::c_ulong,
         up: *mut optee_utee_sys::utee_params,
         cmd_id: libc::c_ulong,
-    );
+    ) -> optee_utee_sys::TEE_Result;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn __ta_entry(
+    func: libc::c_ulong,
+    session_id: libc::c_ulong,
+    up: *mut optee_utee_sys::utee_params,
+    cmd_id: libc::c_ulong,
+) -> ! {
+    let res: optee_utee_sys::TEE_Result = __utee_entry(func, session_id, up, cmd_id);
+
+    optee_utee_sys::utee_return(res.into());
 }
 
 #[no_mangle]
@@ -19,13 +31,7 @@ pub static ta_head: optee_utee_sys::ta_head = optee_utee_sys::ta_head {
     uuid: TA_UUID,
     stack_size: TA_STACK_SIZE + TA_FRAMEWORK_STACK_SIZE,
     flags: TA_FLAGS,
-    entry: __utee_entry
-        as unsafe extern "C" fn(
-            libc::c_ulong,
-            libc::c_ulong,
-            *mut optee_utee_sys::utee_params,
-            libc::c_ulong,
-        ),
+    depr_entry: 0xFFFF_FFFF_FFFF_FFFF,
 };
 
 #[no_mangle]

--- a/examples/secure_storage/ta/Makefile
+++ b/examples/secure_storage/ta/Makefile
@@ -8,13 +8,13 @@ OPTEE_DIR ?= ../../../optee
 
 ifeq ($(ARCH), arm)
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/aarch32/bin
 	OBJCOPY := $(OPTEE_BIN)/arm-linux-gnueabihf-objcopy
 	TARGET := arm-unknown-optee-trustzone
 else
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/$(ARCH)/bin
 	OBJCOPY := $(OPTEE_BIN)/aarch64-linux-gnu-objcopy
 	TARGET := aarch64-unknown-optee-trustzone

--- a/examples/secure_storage/ta/ta_aarch64.lds
+++ b/examples/secure_storage/ta/ta_aarch64.lds
@@ -1,92 +1,62 @@
-OUTPUT_FORMAT("elf64-littleaarch64", "elf64-bigaarch64", "elf64-littleaarch64")
+OUTPUT_FORMAT("elf64-littleaarch64")
 OUTPUT_ARCH(aarch64)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }
-

--- a/examples/secure_storage/ta/ta_arm.lds
+++ b/examples/secure_storage/ta/ta_arm.lds
@@ -1,91 +1,62 @@
 OUTPUT_FORMAT("elf32-littlearm")
 OUTPUT_ARCH(arm)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }

--- a/examples/secure_storage/ta/ta_static.rs
+++ b/examples/secure_storage/ta/ta_static.rs
@@ -5,12 +5,24 @@ pub static mut trace_level: libc::c_int = TRACE_LEVEL;
 pub static trace_ext_prefix: &[u8] = TRACE_EXT_PREFIX;
 
 extern "C" {
-    fn __utee_entry(
+    pub fn __utee_entry(
         func: libc::c_ulong,
         session_id: libc::c_ulong,
         up: *mut optee_utee_sys::utee_params,
         cmd_id: libc::c_ulong,
-    );
+    ) -> optee_utee_sys::TEE_Result;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn __ta_entry(
+    func: libc::c_ulong,
+    session_id: libc::c_ulong,
+    up: *mut optee_utee_sys::utee_params,
+    cmd_id: libc::c_ulong,
+) -> ! {
+    let res: optee_utee_sys::TEE_Result = __utee_entry(func, session_id, up, cmd_id);
+
+    optee_utee_sys::utee_return(res.into());
 }
 
 #[no_mangle]
@@ -19,13 +31,7 @@ pub static ta_head: optee_utee_sys::ta_head = optee_utee_sys::ta_head {
     uuid: TA_UUID,
     stack_size: TA_STACK_SIZE + TA_FRAMEWORK_STACK_SIZE,
     flags: TA_FLAGS,
-    entry: __utee_entry
-        as unsafe extern "C" fn(
-            libc::c_ulong,
-            libc::c_ulong,
-            *mut optee_utee_sys::utee_params,
-            libc::c_ulong,
-        ),
+    depr_entry: 0xFFFF_FFFF_FFFF_FFFF,
 };
 
 #[no_mangle]

--- a/examples/serde/ta/Makefile
+++ b/examples/serde/ta/Makefile
@@ -8,13 +8,13 @@ OPTEE_DIR ?= ../../../optee
 
 ifeq ($(ARCH), arm)
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/aarch32/bin
 	OBJCOPY := $(OPTEE_BIN)/arm-linux-gnueabihf-objcopy
 	TARGET := arm-unknown-optee-trustzone
 else
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/$(ARCH)/bin
 	OBJCOPY := $(OPTEE_BIN)/aarch64-linux-gnu-objcopy
 	TARGET := aarch64-unknown-optee-trustzone

--- a/examples/serde/ta/ta_aarch64.lds
+++ b/examples/serde/ta/ta_aarch64.lds
@@ -1,92 +1,62 @@
-OUTPUT_FORMAT("elf64-littleaarch64", "elf64-bigaarch64", "elf64-littleaarch64")
+OUTPUT_FORMAT("elf64-littleaarch64")
 OUTPUT_ARCH(aarch64)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }
-

--- a/examples/serde/ta/ta_arm.lds
+++ b/examples/serde/ta/ta_arm.lds
@@ -1,91 +1,62 @@
 OUTPUT_FORMAT("elf32-littlearm")
 OUTPUT_ARCH(arm)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }

--- a/examples/serde/ta/ta_static.rs
+++ b/examples/serde/ta/ta_static.rs
@@ -5,12 +5,24 @@ pub static mut trace_level: libc::c_int = TRACE_LEVEL;
 pub static trace_ext_prefix: &[u8] = TRACE_EXT_PREFIX;
 
 extern "C" {
-    fn __utee_entry(
+    pub fn __utee_entry(
         func: libc::c_ulong,
         session_id: libc::c_ulong,
         up: *mut optee_utee_sys::utee_params,
         cmd_id: libc::c_ulong,
-    );
+    ) -> optee_utee_sys::TEE_Result;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn __ta_entry(
+    func: libc::c_ulong,
+    session_id: libc::c_ulong,
+    up: *mut optee_utee_sys::utee_params,
+    cmd_id: libc::c_ulong,
+) -> ! {
+    let res: optee_utee_sys::TEE_Result = __utee_entry(func, session_id, up, cmd_id);
+
+    optee_utee_sys::utee_return(res.into());
 }
 
 #[no_mangle]
@@ -19,13 +31,7 @@ pub static ta_head: optee_utee_sys::ta_head = optee_utee_sys::ta_head {
     uuid: TA_UUID,
     stack_size: TA_STACK_SIZE + TA_FRAMEWORK_STACK_SIZE,
     flags: TA_FLAGS,
-    entry: __utee_entry
-        as unsafe extern "C" fn(
-            libc::c_ulong,
-            libc::c_ulong,
-            *mut optee_utee_sys::utee_params,
-            libc::c_ulong,
-        ),
+    depr_entry: 0xFFFF_FFFF_FFFF_FFFF,
 };
 
 #[no_mangle]

--- a/examples/time/ta/Makefile
+++ b/examples/time/ta/Makefile
@@ -8,13 +8,13 @@ OPTEE_DIR ?= ../../../optee
 
 ifeq ($(ARCH), arm)
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm32/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/aarch32/bin
 	OBJCOPY := $(OPTEE_BIN)/arm-linux-gnueabihf-objcopy
 	TARGET := arm-unknown-optee-trustzone
 else
 	TA_SIGN_KEY ?= $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/keys/default_ta.pem
-	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign.py
+	SIGN := $(OPTEE_OS_DIR)/out/arm/export-ta_arm64/scripts/sign_encrypt.py
 	OPTEE_BIN := $(OPTEE_DIR)/toolchains/$(ARCH)/bin
 	OBJCOPY := $(OPTEE_BIN)/aarch64-linux-gnu-objcopy
 	TARGET := aarch64-unknown-optee-trustzone

--- a/examples/time/ta/ta_aarch64.lds
+++ b/examples/time/ta/ta_aarch64.lds
@@ -1,92 +1,62 @@
-OUTPUT_FORMAT("elf64-littleaarch64", "elf64-bigaarch64", "elf64-littleaarch64")
+OUTPUT_FORMAT("elf64-littleaarch64")
 OUTPUT_ARCH(aarch64)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }
-

--- a/examples/time/ta/ta_arm.lds
+++ b/examples/time/ta/ta_arm.lds
@@ -1,91 +1,62 @@
 OUTPUT_FORMAT("elf32-littlearm")
 OUTPUT_ARCH(arm)
 
-PHDRS {
-	/*
-	 * Exec and rodata headers are hard coded to RX and RO
-	 * respectively. This is needed because the binary is relocatable
-	 * and the linker would automatically make any header writeable
-	 * that need to be updated during relocation.
-	 */
-	exec PT_LOAD FLAGS (5);		/* RX */
-	rodata PT_LOAD FLAGS (4);	/* RO */
-	rwdata PT_LOAD;
-	dyn PT_DYNAMIC;
-}
-
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
-	.text : {
-		__text_start = .;
-		*(.text .text.*)
-		*(.stub)
-		*(.glue_7)
-		*(.glue_7t)
-		*(.gnu.linkonce.t.*)
-		/* Workaround for an erratum in ARM's VFP11 coprocessor */
-		*(.vfp11_veneer)
-		PROVIDE(__gnu_mcount_nc = __utee_mcount);
-		__text_end = .;
-	}
+ .ta_head : {*(.ta_head)}
+ .text : {
+  __text_start = .;
+  *(.text .text.*)
+  *(.stub)
+  *(.glue_7)
+  *(.glue_7t)
+  *(.gnu.linkonce.t.*)
+  *(.vfp11_veneer)
+  __text_end = .;
+ }
         .plt : { *(.plt) }
-
-	.eh_frame : { *(.eh_frame) } :rodata
-	.rodata : {
-		*(.gnu.linkonce.r.*)
-		*(.rodata .rodata.*)
-	}
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
+ .eh_frame : { *(.eh_frame) }
+ .rodata : {
+  *(.gnu.linkonce.r.*)
+  *(.rodata .rodata.*)
+ }
+ .ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
-	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
-	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
-	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
-	.rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
-	.rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
-	.rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
-	.rel.dyn : { *(.rel.dyn) }
-	.rel.got : { *(.rel.got) }
-	.rela.got : { *(.rela.got) }
-	.rel.ctors : { *(.rel.ctors) }
-	.rela.ctors : { *(.rela.ctors) }
-	.rel.dtors : { *(.rel.dtors) }
-	.rela.dtors : { *(.rela.dtors) }
-	.rel.init : { *(.rel.init) }
-	.rela.init : { *(.rela.init) }
-	.rel.fini : { *(.rel.fini) }
-	.rela.fini : { *(.rela.fini) }
-	.rel.bss : { *(.rel.bss) }
-	.rela.bss : { *(.rela.bss) }
-	.rel.plt : { *(.rel.plt) }
-	.rela.plt : { *(.rela.plt) }
-	.dynamic : { *(.dynamic) } :dyn :rodata
-	.dynsym : { *(.dynsym) } :rodata
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
-	/* Page align to allow dropping execute bit for RW data */
-	. = ALIGN(4096);
-
-	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-	.bss : {
-		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		__gprof_buf_end = .;
-	}
-
-	/DISCARD/ : { *(.interp) }
+ .dynsym : { *(.dynsym) }
+ .dynstr : { *(.dynstr) }
+ .hash : { *(.hash) }
+ . = ALIGN(4096);
+ .dynamic : { *(.dynamic) }
+ .got : { *(.got.plt) *(.got) }
+ .rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
+ .rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
+ .rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
+ .rela.data : { *(.rela.data) *(.rela.gnu.linkonce.d*) }
+ .rel.rodata : { *(.rel.rodata) *(.rel.gnu.linkonce.r*) }
+ .rela.rodata : { *(.rela.rodata) *(.rela.gnu.linkonce.r*) }
+ .rel.dyn : { *(.rel.dyn) }
+ .rel.got : { *(.rel.got) }
+ .rela.got : { *(.rela.got) }
+ .rel.ctors : { *(.rel.ctors) }
+ .rela.ctors : { *(.rela.ctors) }
+ .rel.dtors : { *(.rel.dtors) }
+ .rela.dtors : { *(.rela.dtors) }
+ .rel.init : { *(.rel.init) }
+ .rela.init : { *(.rela.init) }
+ .rel.fini : { *(.rel.fini) }
+ .rela.fini : { *(.rela.fini) }
+ .rel.bss : { *(.rel.bss) }
+ .rela.bss : { *(.rela.bss) }
+ .rel.plt : { *(.rel.plt) }
+ .rela.plt : { *(.rela.plt) }
+ .data : { *(.data .data.* .gnu.linkonce.d.*) }
+ .bss : {
+  *(.bss .bss.* .gnu.linkonce.b.* COMMON)
+  . = ALIGN(8);
+  __ftrace_buf_start = .;
+  . += DEFINED(__gnu_mcount_nc) ?
+   2048 : 0;
+  __ftrace_buf_end = .;
+ }
+ /DISCARD/ : { *(.interp) }
 }

--- a/examples/time/ta/ta_static.rs
+++ b/examples/time/ta/ta_static.rs
@@ -5,12 +5,24 @@ pub static mut trace_level: libc::c_int = TRACE_LEVEL;
 pub static trace_ext_prefix: &[u8] = TRACE_EXT_PREFIX;
 
 extern "C" {
-    fn __utee_entry(
+    pub fn __utee_entry(
         func: libc::c_ulong,
         session_id: libc::c_ulong,
         up: *mut optee_utee_sys::utee_params,
         cmd_id: libc::c_ulong,
-    );
+    ) -> optee_utee_sys::TEE_Result;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn __ta_entry(
+    func: libc::c_ulong,
+    session_id: libc::c_ulong,
+    up: *mut optee_utee_sys::utee_params,
+    cmd_id: libc::c_ulong,
+) -> ! {
+    let res: optee_utee_sys::TEE_Result = __utee_entry(func, session_id, up, cmd_id);
+
+    optee_utee_sys::utee_return(res.into());
 }
 
 #[no_mangle]
@@ -19,13 +31,7 @@ pub static ta_head: optee_utee_sys::ta_head = optee_utee_sys::ta_head {
     uuid: TA_UUID,
     stack_size: TA_STACK_SIZE + TA_FRAMEWORK_STACK_SIZE,
     flags: TA_FLAGS,
-    entry: __utee_entry
-        as unsafe extern "C" fn(
-            libc::c_ulong,
-            libc::c_ulong,
-            *mut optee_utee_sys::utee_params,
-            libc::c_ulong,
-        ),
+    depr_entry: 0xFFFF_FFFF_FFFF_FFFF,
 };
 
 #[no_mangle]

--- a/optee-utee/optee-utee-sys/src/tee_api_private.rs
+++ b/optee-utee/optee-utee-sys/src/tee_api_private.rs
@@ -2,5 +2,5 @@ use libc::*;
 use super::*;
 
 extern "C" {
-    pub fn __utee_entry(func: c_ulong, session_id: c_ulong, up: *mut utee_params, cmd_id: c_ulong);
+    pub fn __utee_entry(func: c_ulong, session_id: c_ulong, up: *mut utee_params, cmd_id: c_ulong) -> optee_utee_sys::TEE_Result;
 }

--- a/optee-utee/optee-utee-sys/src/user_ta_header.rs
+++ b/optee-utee/optee-utee-sys/src/user_ta_header.rs
@@ -1,5 +1,4 @@
 use super::tee_api_types::*;
-use super::utee_types::*;
 use libc::*;
 
 pub const TA_FLAG_SINGLE_INSTANCE: u32 = (1 << 2);
@@ -16,7 +15,7 @@ pub struct ta_head {
     pub uuid: TEE_UUID,
     pub stack_size: u32,
     pub flags: u32,
-    pub entry: unsafe extern "C" fn(c_ulong, c_ulong, *mut utee_params, c_ulong),
+    pub depr_entry: u64,
 }
 
 unsafe impl Sync for ta_head {}

--- a/optee-utee/optee-utee-sys/src/utee_syscalls.rs
+++ b/optee-utee/optee-utee-sys/src/utee_syscalls.rs
@@ -2,7 +2,7 @@ use super::*;
 use libc::*;
 
 extern "C" {
-    pub fn utee_return(ret: c_ulong);
+    pub fn utee_return(ret: c_ulong) -> !;
     pub fn utee_log(buf: *const c_void, len: size_t);
     pub fn utee_panic(code: c_ulong);
     pub fn utee_get_property(

--- a/optee-utee/systest/build.rs
+++ b/optee-utee/systest/build.rs
@@ -33,7 +33,7 @@ fn main() {
             || s == "user_ta_property"
     });
     cfg.skip_field(|s, field| {
-        (s == "ta_head" && field == "entry")
+        (s == "ta_head" && field == "depr_entry")
             || field == "content"
             || field == "value"
             || field == "memref"


### PR DESCRIPTION
Hi @mssun ,

Thanks for your help! I've updated:
1. the linker scripts according to [here](https://github.com/OP-TEE/optee_os/blob/3.8.0/ta/arch/arm/ta.ld.S) 
2. gcc linker arguments according to [here](https://github.com/OP-TEE/optee_os/blob/3.8.0/ta/arch/arm/link.mk#L29)
3. the ta header
4. the ta entry point according to [here](https://github.com/OP-TEE/optee_os/blob/3.8.0/ta/arch/arm/user_ta_header.c#L38)

PS: Maybe it will be better if we can put `ta_aarch64.lds`, `ta_arm.lds` and `ta_static.rs` in one directory instead of duplicating them in every TAs.

See #21 for the bug report.

Thanks,
Mingyuan