### PR TITLE
add support for new TEE API and update examples/aes/ta

### DIFF
--- a/examples/aes/ta/src/main.rs
+++ b/examples/aes/ta/src/main.rs
@@ -3,7 +3,8 @@
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };
-use optee_utee::{AlgorithmId, Cipher, OperationMode};
+use optee_utee::{is_algorithm_supported};
+use optee_utee::{AlgorithmId, ElementId, Cipher, OperationMode};
 use optee_utee::{AttributeId, AttributeMemref, TransientObject, TransientObjectType};
 use optee_utee::{Error, ErrorKind, Parameters, Result};
 use proto::{Algo, Command, KeySize, Mode};
@@ -99,6 +100,9 @@ pub fn alloc_resources(aes: &mut AesCipher, params: &mut Parameters) -> Result<(
     let mode_id_value = unsafe { params.2.as_value().unwrap().a() };
 
     aes.key_size = ta2tee_key_size(key_size_value).unwrap();
+
+    // check whether the algorithm is supported
+    is_algorithm_supported(ta2tee_algo_id(algo_value).unwrap() as u32, ElementId::ElementNone as u32)?;
 
     aes.cipher = Cipher::allocate(
         ta2tee_algo_id(algo_value).unwrap(),

--- a/optee-utee/optee-utee-sys/src/tee_api.rs
+++ b/optee-utee/optee-utee-sys/src/tee_api.rs
@@ -253,6 +253,10 @@ extern "C" {
         dstOperation: TEE_OperationHandle,
         srcOperation: TEE_OperationHandle,
     ) -> c_void;
+    pub fn TEE_IsAlgorithmSupported(
+        algId: u32,
+        element: u32, 
+    ) -> TEE_Result;
 
     // Cryptographic Operations API - Message Digest Functions
 

--- a/optee-utee/src/crypto_op.rs
+++ b/optee-utee/src/crypto_op.rs
@@ -209,6 +209,14 @@ impl OperationHandle {
     }
 }
 
+/// determine whether a combination of algId and element is supported
+pub fn is_algorithm_supported(alg_id: u32, element: u32) -> Result<()> {
+    match unsafe { raw::TEE_IsAlgorithmSupported(alg_id, element) } {
+        raw::TEE_SUCCESS => Ok(()),
+        code => Err(Error::from_raw_error(code)),
+    }
+}
+
 // free before check it's not null
 /// Deallocate all resources associated with an operation handle. After this function is called,
 /// the operation handle is no longer valid. All cryptographic material in the operation is destroyed.
@@ -1724,6 +1732,9 @@ pub enum AlgorithmId {
 /// This specification defines support for optional cryptographic elements.
 #[repr(u32)]
 pub enum ElementId {
+    /// Where algId fully defines the required support,
+    /// the special value TEE_CRYPTO_ELEMENT_NONE should be used
+    ElementNone = 0x00000000,
     /// Source: `NIST`, Generic: `Y`, Size: 192 bits
     EccCurveNistP192 = 0x00000001,
     /// Source: `NIST`, Generic: `Y`, Size: 224 bits
@@ -1735,4 +1746,3 @@ pub enum ElementId {
     /// Source: `NIST`, Generic: `Y`, Size: 521 bits
     EccCurveNistP521 = 0x00000005,
 }
-//OP-TEE does not implement function: TEE_IsAlgorithmSuppddorted


### PR DESCRIPTION
Hi @mssun 
A new API was defined in OPTEE 3.9.0+ which is `TEE_IsAlgorithmSupported`.
So I've updated:

1. function wrapper `is_algorithm_supported` for `TEE_IsAlgorithmSupported`
2. examples/aes/ta to test `is_algorithm_supported`

Best Regards,
Yuan